### PR TITLE
Remove filehandle limit for kafka machines

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,3 +18,5 @@ default["kafka"]["log_dirs"] = ["/tmp/kafka-logs"]
 default["kafka"]["zookeeper_nodes"] = []
 default["kafka"]["zookeeper_discovery"] = false
 default["kafka"]["exhibitor_endpoint"]  = nil
+
+default["kafka"]["filehandle_limit"] = 262_144

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,3 +7,4 @@ long_description "Installs and configures kafka"
 version          "0.1.0"
 
 depends "runit", "~> 1.5.14"
+depends "ulimit", "~> 0.3"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -38,7 +38,7 @@ user node["kafka"]["user"] do
 end
 
 user_ulimit node["kafka"]["user"] do
-  filehandle_limit 262_144
+  filehandle_limit node["kafka"]["filehandle_limit"]
 end
 
 full_version  = "#{node["kafka"]["scala_version"]}-#{node["kafka"]["version"]}"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -37,6 +37,10 @@ user node["kafka"]["user"] do
   system  true
 end
 
+user_ulimit node["kafka"]["user"] do
+  filehandle_limit 262_144
+end
+
 full_version  = "#{node["kafka"]["scala_version"]}-#{node["kafka"]["version"]}"
 download_url  = "#{node["kafka"]["apache_mirror"]}/kafka/#{node["kafka"]["version"]}/kafka_#{full_version}.tgz"
 kafka_archive = "#{Chef::Config[:file_cache_path]}/#{File.basename(download_url)}"

--- a/templates/default/sv-kafka-run.erb
+++ b/templates/default/sv-kafka-run.erb
@@ -1,5 +1,6 @@
 #!/bin/bash
 exec 2>&1
+ulimit -n <%= node["kafka"]["filehandle_limit"] %>
 exec chpst<% if !node["kafka"]["service_env"].empty? %> -e ./env<% end %> -u <%= node["kafka"]["user"] %> \
   <%= node["kafka"]["current_path"] %>/bin/kafka-server-start.sh \
   <%= node["kafka"]["current_path"] %>/config/server.properties


### PR DESCRIPTION
Add ulimit cookbook dependency and command to remove file descriptor limit.

PLATFORM-121

@robotblake I am going to use vagrant to run the recipe on to see if it works.
