### PR TITLE
Upgrade Kafka to 0.10.0.0

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,5 @@
 default["kafka"]["version"] = "0.10.0.0"
-default["kafka"]["broker_protocol_version"]="0.9.0.1"
+default["kafka"]["broker_protocol_version"]="0.10.0.0"
 default["kafka"]["log_message_format"]="0.9.0.1"
 default["kafka"]["scala_version"] = "2.11"
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,6 @@
-default["kafka"]["version"] = "0.9.0.1"
+default["kafka"]["version"] = "0.10.0.0"
+default["kafka"]["broker_protocol_version"]="0.9.0.1"
+default["kafka"]["log_message_format"]="0.9.0.1"
 default["kafka"]["scala_version"] = "2.11"
 
 default["kafka"]["apache_mirror"] = "http://apache.osuosl.org"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,6 @@
 default["kafka"]["version"] = "0.10.0.0"
 default["kafka"]["broker_protocol_version"]="0.10.0.0"
-default["kafka"]["log_message_format"]="0.9.0.1"
+default["kafka"]["log_message_format"]="0.10.0.0"
 default["kafka"]["scala_version"] = "2.11"
 
 default["kafka"]["apache_mirror"] = "http://apache.osuosl.org"

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,10 +1,10 @@
 name             "apptentive_kafka"
 maintainer       "Apptentive, Inc."
-maintainer_email "blake@apptentive.com"
+maintainer_email "engineering@apptentive.com"
 license          "mit"
 description      "Installs and configures kafka"
 long_description "Installs and configures kafka"
-version          "0.1.0"
+version          "0.3.0"
 
 depends "runit", "~> 1.5.14"
 depends "ulimit", "~> 0.3"

--- a/templates/default/server.properties.erb
+++ b/templates/default/server.properties.erb
@@ -26,6 +26,13 @@
 <% end %>
 broker.id.generation.enable=true
 
+# The format between brokers, which should not be updated until all brokers have the underlying code for that version
+inter.broker.protocol.version=<%= node["kafka"]["broker_protocol_version"] %>
+
+# The message format stored in brokers
+# If an older consumer consumes a newer message type, the broker must down-convert it instead of using zero-copy transfer
+log.message.format.version=<%= node["kafka"]["log_message_format"] %>
+
 ############################# Socket Server Settings #############################
 
 listeners=PLAINTEXT://<%= node[:ipaddress] %>:9092


### PR DESCRIPTION
Keep the inter-broker format at 0.9.0.1 until all brokers are
updated, when it will be bumped to 0.10.0.0.

Store messages in brokers as 0.10.0.0. They will be down-converted to
the version required by the consumer. I am curious if this also applies
to the inter.broker version as well.

PLATFORM-1276

@msaffitz 
