### PR TITLE
Change message timestamp to be log-append-time.

### DIFF
--- a/templates/default/server.properties.erb
+++ b/templates/default/server.properties.erb
@@ -138,8 +138,6 @@ zookeeper.connection.timeout.ms=6000
 
 # "Sensible Defaults"
 auto.create.topics.enable=false
-controlled.shutdown.enable=true
-auto.leader.rebalance.enable=true
 log.message.timestamp.type=LogAppendTime
 default.replication.factor=3
 delete.topic.enable=true

--- a/templates/default/server.properties.erb
+++ b/templates/default/server.properties.erb
@@ -136,5 +136,11 @@ zookeeper.connect=<%= node["kafka"]["zookeeper_nodes"].join(?,) %>
 # Timeout in ms for connecting to zookeeper
 zookeeper.connection.timeout.ms=6000
 
+# "Sensible Defaults"
+auto.create.topics.enable=false
+controlled.shutdown.enable=true
+auto.leader.rebalance.enable=true
+log.message.timestamp.type=LogAppendTime
 default.replication.factor=3
 delete.topic.enable=true
+


### PR DESCRIPTION
- Disables topic autocreate (if a topic not existing is a surprise, you've probably got a problem)
- Enable graceful shutdown for servers for maintenance work
- Allow automated leader re-election for partitions (helps when nodes crash and come back online)
- Change log message timestamp to be log-append-time, so that producers that are using older kafka libs still get modern behavior in kafka servers